### PR TITLE
add call to Process.EnterDebugMode()

### DIFF
--- a/psgetsys.ps1
+++ b/psgetsys.ps1
@@ -95,7 +95,7 @@ public class MyProcess
 
         try
         {
-            
+            Process.EnterDebugMode();
             var lpSize = IntPtr.Zero;
             InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref lpSize);
             si.lpAttributeList = Marshal.AllocHGlobal(lpSize);


### PR DESCRIPTION
calling `Process.EnterDebugMode()` will enable `SeDebugPrivilege` on the running thread if the privilege is available but not enabled.